### PR TITLE
Move to newer DragTarget API

### DIFF
--- a/samples/multiplayer/lib/play_session/playing_area_widget.dart
+++ b/samples/multiplayer/lib/play_session/playing_area_widget.dart
@@ -49,9 +49,9 @@ class _PlayingAreaWidgetState extends State<PlayingAreaWidget> {
               ),
             ),
           ),
-          onWillAccept: _onDragWillAccept,
+          onWillAcceptWithDetails: _onDragWillAccept,
           onLeave: _onDragLeave,
-          onAccept: _onDragAccept,
+          onAcceptWithDetails: _onDragAccept,
         ),
       ),
     );
@@ -64,9 +64,9 @@ class _PlayingAreaWidgetState extends State<PlayingAreaWidget> {
     audioController.playSfx(SfxType.huhsh);
   }
 
-  void _onDragAccept(PlayingCardDragData data) {
-    widget.area.acceptCard(data.card);
-    data.holder.removeCard(data.card);
+  void _onDragAccept(DragTargetDetails<PlayingCardDragData> details) {
+    widget.area.acceptCard(details.data.card);
+    details.data.holder.removeCard(details.data.card);
     setState(() => isHighlighted = false);
   }
 
@@ -74,8 +74,7 @@ class _PlayingAreaWidgetState extends State<PlayingAreaWidget> {
     setState(() => isHighlighted = false);
   }
 
-  bool _onDragWillAccept(PlayingCardDragData? data) {
-    if (data == null) return false;
+  bool _onDragWillAccept(DragTargetDetails<PlayingCardDragData> details) {
     setState(() => isHighlighted = true);
     return true;
   }

--- a/templates/card/lib/play_session/playing_area_widget.dart
+++ b/templates/card/lib/play_session/playing_area_widget.dart
@@ -49,9 +49,9 @@ class _PlayingAreaWidgetState extends State<PlayingAreaWidget> {
               ),
             ),
           ),
-          onWillAccept: _onDragWillAccept,
+          onWillAcceptWithDetails: _onDragWillAccept,
           onLeave: _onDragLeave,
-          onAccept: _onDragAccept,
+          onAcceptWithDetails: _onDragAccept,
         ),
       ),
     );
@@ -64,9 +64,9 @@ class _PlayingAreaWidgetState extends State<PlayingAreaWidget> {
     audioController.playSfx(SfxType.huhsh);
   }
 
-  void _onDragAccept(PlayingCardDragData data) {
-    widget.area.acceptCard(data.card);
-    data.holder.removeCard(data.card);
+  void _onDragAccept(DragTargetDetails<PlayingCardDragData> details) {
+    widget.area.acceptCard(details.data.card);
+    details.data.holder.removeCard(details.data.card);
     setState(() => isHighlighted = false);
   }
 
@@ -74,8 +74,7 @@ class _PlayingAreaWidgetState extends State<PlayingAreaWidget> {
     setState(() => isHighlighted = false);
   }
 
-  bool _onDragWillAccept(PlayingCardDragData? data) {
-    if (data == null) return false;
+  bool _onDragWillAccept(DragTargetDetails<PlayingCardDragData> details) {
     setState(() => isHighlighted = true);
     return true;
   }


### PR DESCRIPTION
Uses the newer `onWillAcceptWithDetails` and `onAcceptWithDetails` fields of `DragTarget`. The older API is deprecated in the current Flutter `beta` branch.

Fixes the CI build.


## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/games/blob/main/CONTRIBUTING.md
