### PR TITLE
Add template version to AndroidManifest.xml and Info.plist

### DIFF
--- a/templates/basic/android/app/src/main/AndroidManifest.xml
+++ b/templates/basic/android/app/src/main/AndroidManifest.xml
@@ -19,7 +19,7 @@
               android:name="io.flutter.embedding.android.NormalTheme"
               android:resource="@style/NormalTheme"
               />
-            <!-- Specifies the version of the game template for tracking purposes. -->
+            <!-- Specifies the version of the game template to understand template usage. -->
             <meta-data
                 android:name="io.flutter.plugins.googlemobileads.FLUTTER_GAME_TEMPLATE_VERSION"
                 android:value="1.0.0"/>

--- a/templates/basic/android/app/src/main/AndroidManifest.xml
+++ b/templates/basic/android/app/src/main/AndroidManifest.xml
@@ -19,6 +19,10 @@
               android:name="io.flutter.embedding.android.NormalTheme"
               android:resource="@style/NormalTheme"
               />
+            <!-- Specifies the version of the game template for tracking purposes. -->
+            <meta-data
+                android:name="io.flutter.plugins.googlemobileads.FLUTTER_GAME_TEMPLATE_VERSION"
+                android:value="1.0.0"/>
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>

--- a/templates/basic/ios/Runner/Info.plist
+++ b/templates/basic/ios/Runner/Info.plist
@@ -45,5 +45,7 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>FLTGameTemplateVersion</key>
+    <string>1.0.0</string>
 </dict>
 </plist>

--- a/templates/card/android/app/src/main/AndroidManifest.xml
+++ b/templates/card/android/app/src/main/AndroidManifest.xml
@@ -19,7 +19,7 @@
               android:name="io.flutter.embedding.android.NormalTheme"
               android:resource="@style/NormalTheme"
               />
-            <!-- Specifies the version of the game template for tracking purposes. -->
+            <!-- Specifies the version of the game template to understand template usage. -->
             <meta-data
                 android:name="io.flutter.plugins.googlemobileads.FLUTTER_GAME_TEMPLATE_VERSION"
                 android:value="1.0.0"/>

--- a/templates/card/android/app/src/main/AndroidManifest.xml
+++ b/templates/card/android/app/src/main/AndroidManifest.xml
@@ -19,6 +19,10 @@
               android:name="io.flutter.embedding.android.NormalTheme"
               android:resource="@style/NormalTheme"
               />
+            <!-- Specifies the version of the game template for tracking purposes. -->
+            <meta-data
+                android:name="io.flutter.plugins.googlemobileads.FLUTTER_GAME_TEMPLATE_VERSION"
+                android:value="1.0.0"/>
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>

--- a/templates/card/ios/Runner/Info.plist
+++ b/templates/card/ios/Runner/Info.plist
@@ -45,5 +45,7 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>FLTGameTemplateVersion</key>
+    <string>1.0.0</string>
 </dict>
 </plist>

--- a/templates/endless_runner/android/app/src/main/AndroidManifest.xml
+++ b/templates/endless_runner/android/app/src/main/AndroidManifest.xml
@@ -19,7 +19,7 @@
               android:name="io.flutter.embedding.android.NormalTheme"
               android:resource="@style/NormalTheme"
               />
-            <!-- Specifies the version of the game template for tracking purposes. -->
+            <!-- Specifies the version of the game template to understand template usage. -->
             <meta-data
                 android:name="io.flutter.plugins.googlemobileads.FLUTTER_GAME_TEMPLATE_VERSION"
                 android:value="1.0.0"/>

--- a/templates/endless_runner/android/app/src/main/AndroidManifest.xml
+++ b/templates/endless_runner/android/app/src/main/AndroidManifest.xml
@@ -19,6 +19,10 @@
               android:name="io.flutter.embedding.android.NormalTheme"
               android:resource="@style/NormalTheme"
               />
+            <!-- Specifies the version of the game template for tracking purposes. -->
+            <meta-data
+                android:name="io.flutter.plugins.googlemobileads.FLUTTER_GAME_TEMPLATE_VERSION"
+                android:value="1.0.0"/>
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>

--- a/templates/endless_runner/ios/Runner/Info.plist
+++ b/templates/endless_runner/ios/Runner/Info.plist
@@ -45,5 +45,7 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>FLTGameTemplateVersion</key>
+    <string>1.0.0</string>
 </dict>
 </plist>


### PR DESCRIPTION
For tracking purposes, we're adding a key-value pair to each game template. This can be used by the AdMob plugin to recognize that this is a Flutter game built on top of the template.


## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/games/blob/main/CONTRIBUTING.md
