### PR TITLE
Rename key of audioOn to 'audioOn'

### DIFF
--- a/samples/ads/lib/settings/persistence/local_storage_settings_persistence.dart
+++ b/samples/ads/lib/settings/persistence/local_storage_settings_persistence.dart
@@ -15,7 +15,7 @@ class LocalStorageSettingsPersistence extends SettingsPersistence {
   @override
   Future<bool> getAudioOn({required bool defaultValue}) async {
     final prefs = await instanceFuture;
-    return prefs.getBool('mute') ?? defaultValue;
+    return prefs.getBool('audioOn') ?? defaultValue;
   }
 
   @override
@@ -39,7 +39,7 @@ class LocalStorageSettingsPersistence extends SettingsPersistence {
   @override
   Future<void> saveAudioOn(bool value) async {
     final prefs = await instanceFuture;
-    await prefs.setBool('mute', value);
+    await prefs.setBool('audioOn', value);
   }
 
   @override

--- a/samples/multiplayer/lib/settings/persistence/local_storage_settings_persistence.dart
+++ b/samples/multiplayer/lib/settings/persistence/local_storage_settings_persistence.dart
@@ -15,7 +15,7 @@ class LocalStorageSettingsPersistence extends SettingsPersistence {
   @override
   Future<bool> getAudioOn({required bool defaultValue}) async {
     final prefs = await instanceFuture;
-    return prefs.getBool('mute') ?? defaultValue;
+    return prefs.getBool('audioOn') ?? defaultValue;
   }
 
   @override
@@ -39,7 +39,7 @@ class LocalStorageSettingsPersistence extends SettingsPersistence {
   @override
   Future<void> saveAudioOn(bool value) async {
     final prefs = await instanceFuture;
-    await prefs.setBool('mute', value);
+    await prefs.setBool('audioOn', value);
   }
 
   @override

--- a/templates/basic/lib/settings/persistence/local_storage_settings_persistence.dart
+++ b/templates/basic/lib/settings/persistence/local_storage_settings_persistence.dart
@@ -15,7 +15,7 @@ class LocalStorageSettingsPersistence extends SettingsPersistence {
   @override
   Future<bool> getAudioOn({required bool defaultValue}) async {
     final prefs = await instanceFuture;
-    return prefs.getBool('mute') ?? defaultValue;
+    return prefs.getBool('audioOn') ?? defaultValue;
   }
 
   @override
@@ -39,7 +39,7 @@ class LocalStorageSettingsPersistence extends SettingsPersistence {
   @override
   Future<void> saveAudioOn(bool value) async {
     final prefs = await instanceFuture;
-    await prefs.setBool('mute', value);
+    await prefs.setBool('audioOn', value);
   }
 
   @override

--- a/templates/card/lib/settings/persistence/local_storage_settings_persistence.dart
+++ b/templates/card/lib/settings/persistence/local_storage_settings_persistence.dart
@@ -15,7 +15,7 @@ class LocalStorageSettingsPersistence extends SettingsPersistence {
   @override
   Future<bool> getAudioOn({required bool defaultValue}) async {
     final prefs = await instanceFuture;
-    return prefs.getBool('mute') ?? defaultValue;
+    return prefs.getBool('audioOn') ?? defaultValue;
   }
 
   @override
@@ -39,7 +39,7 @@ class LocalStorageSettingsPersistence extends SettingsPersistence {
   @override
   Future<void> saveAudioOn(bool value) async {
     final prefs = await instanceFuture;
-    await prefs.setBool('mute', value);
+    await prefs.setBool('audioOn', value);
   }
 
   @override

--- a/templates/endless_runner/lib/settings/persistence/local_storage_settings_persistence.dart
+++ b/templates/endless_runner/lib/settings/persistence/local_storage_settings_persistence.dart
@@ -11,7 +11,7 @@ class LocalStorageSettingsPersistence extends SettingsPersistence {
   @override
   Future<bool> getAudioOn({required bool defaultValue}) async {
     final prefs = await instanceFuture;
-    return prefs.getBool('mute') ?? defaultValue;
+    return prefs.getBool('audioOn') ?? defaultValue;
   }
 
   @override
@@ -35,7 +35,7 @@ class LocalStorageSettingsPersistence extends SettingsPersistence {
   @override
   Future<void> saveAudioOn(bool value) async {
     final prefs = await instanceFuture;
-    await prefs.setBool('mute', value);
+    await prefs.setBool('audioOn', value);
   }
 
   @override


### PR DESCRIPTION
I neglected to change the name of the `shared_preferences` key from “mute” to “audioOn”. This has no effect on the logic (the key could be named “kerfuffle” and it would still work). It’s just confusing to anyone reading that code.

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/games/blob/main/CONTRIBUTING.md
