### PR TITLE
Enforce strict casts rule

### DIFF
--- a/samples/ads/analysis_options.yaml
+++ b/samples/ads/analysis_options.yaml
@@ -1,5 +1,9 @@
 include: package:flutter_lints/flutter.yaml
 
+analyzer:
+  language:
+    strict-casts: true
+
 linter:
   rules:
     # Remove or force lint rules by adding lines like the following.

--- a/samples/multiplayer/analysis_options.yaml
+++ b/samples/multiplayer/analysis_options.yaml
@@ -1,5 +1,9 @@
 include: package:flutter_lints/flutter.yaml
 
+analyzer:
+  language:
+    strict-casts: true
+
 linter:
   rules:
     # Remove or force lint rules by adding lines like the following.

--- a/samples/multiplayer/lib/game_internals/playing_card.dart
+++ b/samples/multiplayer/lib/game_internals/playing_card.dart
@@ -18,7 +18,7 @@ class PlayingCard {
     return PlayingCard(
       CardSuit.values
           .singleWhere((e) => e.internalRepresentation == json['suit']),
-      json['value'],
+      json['value'] as int,
     );
   }
 

--- a/samples/multiplayer/lib/multiplayer/firestore_controller.dart
+++ b/samples/multiplayer/lib/multiplayer/firestore_controller.dart
@@ -72,7 +72,7 @@ class FirestoreController {
     DocumentSnapshot<Map<String, dynamic>> snapshot,
     SnapshotOptions? options,
   ) {
-    final data = snapshot.data()?['cards'];
+    final data = snapshot.data()?['cards'] as List?;
 
     if (data == null) {
       _log.info('No data found on Firestore, returning empty list');

--- a/templates/basic/analysis_options.yaml
+++ b/templates/basic/analysis_options.yaml
@@ -1,5 +1,9 @@
 include: package:flutter_lints/flutter.yaml
 
+analyzer:
+  language:
+    strict-casts: true
+
 linter:
   rules:
     # Remove or force lint rules by adding lines like the following.

--- a/templates/card/analysis_options.yaml
+++ b/templates/card/analysis_options.yaml
@@ -1,5 +1,9 @@
 include: package:flutter_lints/flutter.yaml
 
+analyzer:
+  language:
+    strict-casts: true
+
 linter:
   rules:
     # Remove or force lint rules by adding lines like the following.

--- a/templates/card/lib/game_internals/playing_card.dart
+++ b/templates/card/lib/game_internals/playing_card.dart
@@ -18,7 +18,7 @@ class PlayingCard {
     return PlayingCard(
       CardSuit.values
           .singleWhere((e) => e.internalRepresentation == json['suit']),
-      json['value'],
+      json['value'] as int,
     );
   }
 

--- a/templates/endless_runner/analysis_options.yaml
+++ b/templates/endless_runner/analysis_options.yaml
@@ -1,1 +1,5 @@
 include: package:flutter_lints/flutter.yaml
+
+analyzer:
+  language:
+    strict-casts: true


### PR DESCRIPTION
The `strict-casts` analyzer option is enabled on `flutter/website` sample code and possibly makes sense to enable here as well. It is the modern version of the old “implicit-casts” strong mode option. https://dart.dev/tools/analysis#enabling-additional-type-checks

I am pretty sure that we want to make the code changes, such as:

```dart
    return PlayingCard(
      CardSuit.values
          .singleWhere((e) => e.internalRepresentation == json['suit']),
      json['value'] as int,  // <-- added explicit type cast
    );
```

But I'm not sure we also want to enable the stricter analyzer:

```yaml
analyzer:
  language:
    strict-casts: true
```

It makes code less surprising, and it's a long-term win for any _serious_ project, imho, but it can also be frustrating and obscure for newcomers who just want to, say, parse some JSON real quick, thank you very much.



## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/games/blob/main/CONTRIBUTING.md
