### PR TITLE
fix(endless_runner): Update height of win screen

### DIFF
--- a/templates/endless_runner/lib/flame_game/game_win_dialog.dart
+++ b/templates/endless_runner/lib/flame_game/game_win_dialog.dart
@@ -29,7 +29,7 @@ class GameWinDialog extends StatelessWidget {
     return Center(
       child: NesContainer(
         width: 420,
-        height: 280,
+        height: 300,
         backgroundColor: palette.backgroundPlaySession.color,
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,

--- a/templates/endless_runner/pubspec.yaml
+++ b/templates/endless_runner/pubspec.yaml
@@ -10,22 +10,22 @@ environment:
   sdk: ^3.0.0
 
 dependencies:
-  flame: ^1.10.1
+  flame: ^1.14.0
   flutter:
     sdk: flutter
 
-  audioplayers: ^5.2.0
+  audioplayers: ^5.2.1
   cupertino_icons: ^1.0.6
-  flame_audio: ^2.1.3
-  go_router: ^12.1.0
-  provider: ^6.0.5
+  flame_audio: ^2.1.7
+  go_router: ^13.1.0
+  provider: ^6.1.1
   shared_preferences: ^2.2.2
-  nes_ui: ^0.10.0
+  nes_ui: ^0.15.0
   google_fonts: ^6.1.0
   logging: ^1.2.0
 
 dev_dependencies:
-  flame_test: ^1.14.0
+  flame_test: ^1.15.3
   flutter_lints: ^3.0.1
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
Updates the height of the win screen which was overflowing due to a update in nes_ui

Closes: https://github.com/flutter/flutter/issues/143028

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/games/blob/main/CONTRIBUTING.md
