### PR TITLE
Fix render overflow on short narrow screens

### DIFF
--- a/samples/multiplayer/lib/play_session/board_widget.dart
+++ b/samples/multiplayer/lib/play_session/board_widget.dart
@@ -29,13 +29,11 @@ class _BoardWidgetState extends State<BoardWidget> {
       children: [
         Padding(
           padding: const EdgeInsets.all(10),
-          child: Wrap(
-            alignment: WrapAlignment.center,
-            spacing: 20,
-            runSpacing: 20,
+          child: Row(
             children: [
-              PlayingAreaWidget(boardState.areaOne),
-              PlayingAreaWidget(boardState.areaTwo),
+              Expanded(child: PlayingAreaWidget(boardState.areaOne)),
+              SizedBox(width: 20),
+              Expanded(child: PlayingAreaWidget(boardState.areaTwo)),
             ],
           ),
         ),

--- a/samples/multiplayer/lib/play_session/playing_area_widget.dart
+++ b/samples/multiplayer/lib/play_session/playing_area_widget.dart
@@ -31,21 +31,18 @@ class _PlayingAreaWidgetState extends State<PlayingAreaWidget> {
       child: AspectRatio(
         aspectRatio: 1 / 1,
         child: DragTarget<PlayingCardDragData>(
-          builder: (context, candidateData, rejectedData) => SizedBox(
-            height: 100,
-            child: Material(
-              color: isHighlighted ? palette.accept : palette.trueWhite,
-              shape: CircleBorder(),
-              clipBehavior: Clip.hardEdge,
-              child: InkWell(
-                splashColor: palette.redPen,
-                onTap: _onAreaTap,
-                child: StreamBuilder(
-                  // Rebuild the card stack whenever the area changes
-                  // (either by a player action, or remotely).
-                  stream: widget.area.allChanges,
-                  builder: (context, child) => _CardStack(widget.area.cards),
-                ),
+          builder: (context, candidateData, rejectedData) => Material(
+            color: isHighlighted ? palette.accept : palette.trueWhite,
+            shape: CircleBorder(),
+            clipBehavior: Clip.hardEdge,
+            child: InkWell(
+              splashColor: palette.redPen,
+              onTap: _onAreaTap,
+              child: StreamBuilder(
+                // Rebuild the card stack whenever the area changes
+                // (either by a player action, or remotely).
+                stream: widget.area.allChanges,
+                builder: (context, child) => _CardStack(widget.area.cards),
               ),
             ),
           ),

--- a/templates/card/lib/play_session/board_widget.dart
+++ b/templates/card/lib/play_session/board_widget.dart
@@ -29,13 +29,11 @@ class _BoardWidgetState extends State<BoardWidget> {
       children: [
         Padding(
           padding: const EdgeInsets.all(10),
-          child: Wrap(
-            alignment: WrapAlignment.center,
-            spacing: 20,
-            runSpacing: 20,
+          child: Row(
             children: [
-              PlayingAreaWidget(boardState.areaOne),
-              PlayingAreaWidget(boardState.areaTwo),
+              Expanded(child: PlayingAreaWidget(boardState.areaOne)),
+              SizedBox(width: 20),
+              Expanded(child: PlayingAreaWidget(boardState.areaTwo)),
             ],
           ),
         ),

--- a/templates/card/lib/play_session/playing_area_widget.dart
+++ b/templates/card/lib/play_session/playing_area_widget.dart
@@ -31,21 +31,18 @@ class _PlayingAreaWidgetState extends State<PlayingAreaWidget> {
       child: AspectRatio(
         aspectRatio: 1 / 1,
         child: DragTarget<PlayingCardDragData>(
-          builder: (context, candidateData, rejectedData) => SizedBox(
-            height: 100,
-            child: Material(
-              color: isHighlighted ? palette.accept : palette.trueWhite,
-              shape: CircleBorder(),
-              clipBehavior: Clip.hardEdge,
-              child: InkWell(
-                splashColor: palette.redPen,
-                onTap: _onAreaTap,
-                child: StreamBuilder(
-                  // Rebuild the card stack whenever the area changes
-                  // (either by a player action, or remotely).
-                  stream: widget.area.allChanges,
-                  builder: (context, child) => _CardStack(widget.area.cards),
-                ),
+          builder: (context, candidateData, rejectedData) => Material(
+            color: isHighlighted ? palette.accept : palette.trueWhite,
+            shape: CircleBorder(),
+            clipBehavior: Clip.hardEdge,
+            child: InkWell(
+              splashColor: palette.redPen,
+              onTap: _onAreaTap,
+              child: StreamBuilder(
+                // Rebuild the card stack whenever the area changes
+                // (either by a player action, or remotely).
+                stream: widget.area.allChanges,
+                builder: (context, child) => _CardStack(widget.area.cards),
               ),
             ),
           ),


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/139132.

I went with a `Row` instead of a `Wrap` when laying out `PlayingAreaWidget`s. While it made sense at first, the `Wrap` didn’t really help on small screens since it made the playing areas very large (the entire width became available once the two areas were given their own run).

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Contributors Guide]: https://github.com/flutter/games/blob/main/CONTRIBUTING.md
