### PR TITLE
Do not update patch versions for `dependabot/github-actions`.

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,6 +7,11 @@ updates:
       interval: "daily"
     labels:
       - "autosubmit"
+    # Updating patch versions for "github-actions" is too chatty.
+    # See https://github.com/flutter/flutter/issues/158350.
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
   - package-ecosystem: "pub"
     directory: "templates/basic/"
     schedule:


### PR DESCRIPTION
Towards https://github.com/flutter/flutter/issues/158350.