### PR TITLE
Fix CI/CD macro failure

### DIFF
--- a/samples/crossword/pubspec.yaml
+++ b/samples/crossword/pubspec.yaml
@@ -24,7 +24,6 @@ dev_dependencies:
   flutter_lints: ^5.0.0
   build_runner: ^2.4.10
   built_value_generator: ^8.9.2
-  custom_lint: ^0.6.8
   riverpod_generator: ^2.6.1
   riverpod_lint: ^2.6.1
 


### PR DESCRIPTION
Removes dependency on `custom_lint` from `samples/crossword`. It was unused, and it led to `pub get` failure on `flutter beta` (because `custom_lint` depended on `analyzer ^6.6.0` and `analyzer >=6.9.0 <7.3.0` depended on `macros` -- a [suspended feature](https://medium.com/dartlang/an-update-on-dart-macros-data-serialization-06d3037d4f12)).

Fixes build breakage.

## Pre-launch Checklist

- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I read the [Contributors Guide].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[Contributors Guide]: https://github.com/flutter/games/blob/main/CONTRIBUTING.md
